### PR TITLE
Player feature auto

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -61,7 +61,14 @@ class Board
 
   def valid_placement?(ship, coordinates)
     @coordinates = coordinates
-    valid_coordinates_suite(ship) && ship_overlap(ship, coordinates)
+    @ship = ship
+    valid_coordinates_suite(ship) && ship_overlap(ship, @coordinates)
+  end
+
+  def validated_placement
+    if (valid_coordinates_suite(@ship) && ship_overlap(@ship, @coordinates)) == true
+      place(@ship, @coordinates)
+    end
   end
 
   def placement_consecutive?

--- a/lib/player.rb
+++ b/lib/player.rb
@@ -31,7 +31,7 @@ class Player
           puts "> "
         end
 
-        user_ship_coords = gets.chomp.split(/ /)
+        user_ship_coords = gets.chomp.upcase.split(/ /)
         # Consider loop for user error
         if @board.valid_placement?(ship, user_ship_coords) == true
           @board.place(ship, user_ship_coords)
@@ -39,7 +39,7 @@ class Player
           loop do
             puts "Those are invalid coordinates. Please try again:"
             puts "> "
-            user_ship_coords = gets.chomp.split(/ /)
+            user_ship_coords = gets.chomp.upcase.split(/ /)
 
             if @board.valid_placement?(ship, user_ship_coords) == true
               @board.place(ship, user_ship_coords)
@@ -63,7 +63,6 @@ class Player
       ships_placed_count
     end
     ships_count == ships_on_board
-    # require "pry"; binding.pry
   end
 
 end

--- a/lib/player.rb
+++ b/lib/player.rb
@@ -12,45 +12,81 @@ class Player
     @ships << ship
   end
 
+
   def ship_setup
     if @type == :auto
-      # helper-method: auto_generation CALLS
-      # helper-method: player_place_ships
-      # auto generation
-      p "type auto"
-    elsif @type == :user
-      # Put in a guard for user error
-
-      # helper-method: player_place_ships
-      @ships.each do |ship|
-        if ship.length == 3
-          puts "Enter the squares for the Cruiser (3 spaces):"
+      #auto generate coordinates
+    else
+      until all_ships_placed?
+        @ships.each do |ship|
+          puts "Enter the squares for the #{ship.name} (#{ship.length} spaces)"
           puts "> "
-        elsif ship.length == 2
-          puts "Enter the squares for the Submarine (2 spaces):"
-          puts "> "
-        end
-
-        user_ship_coords = gets.chomp.upcase.split(/ /)
-        # Consider loop for user error
-        if @board.valid_placement?(ship, user_ship_coords) == true
-          @board.place(ship, user_ship_coords)
-        elsif @board.valid_placement?(ship, user_ship_coords) == false
-          loop do
-            puts "Those are invalid coordinates. Please try again:"
-            puts "> "
-            user_ship_coords = gets.chomp.upcase.split(/ /)
-
-            if @board.valid_placement?(ship, user_ship_coords) == true
-              @board.place(ship, user_ship_coords)
-              # require "pry"; binding.pry
-              exit # Could be a helper-method
-            end
+          user_ship_coords = gets.chomp.upcase.split(/ /)
+          result = @board.valid_placement?(ship, user_ship_coords)
+          if result == false
+            "Develop helper method that tests if this singular ship was placed."
+            # @result2 = false
+            # until @result2 != false
+            #   require "pry"; binding.pry
+            #   puts "Those are invalid coordinates. Please try again: "
+            #   user_ship_coords2 = gets.chomp.upcase.split(/ /)
+            # @result2 != @board.valid_placement?(ship, user_ship_coords2)
+            #make loop for validated_placement
+            # end
+            @board.validated_placement
+          else
+            @board.validated_placement
           end
         end
       end
     end
   end
+
+  def this_ship_placed?(ship)
+    @board.cells.values.any? do |cell|
+      cell.ship == ship
+    end
+  end
+
+  # def ship_setup
+  #   if @type == :auto
+  #     # helper-method: auto_generation CALLS
+  #     # helper-method: player_place_ships
+  #     # auto generation
+  #     p "type auto"
+  #   elsif @type == :user
+  #     # Put in a guard for user error
+  #
+  #     # helper-method: player_place_ships
+  #     @ships.each do |ship|
+  #       if ship.length == 3
+  #         puts "Enter the squares for the Cruiser (3 spaces):"
+  #         puts "> "
+  #       elsif ship.length == 2
+  #         puts "Enter the squares for the Submarine (2 spaces):"
+  #         puts "> "
+  #       end
+  #
+  #       user_ship_coords = gets.chomp.upcase.split(/ /)
+  #       # Consider loop for user error
+  #       if @board.valid_placement?(ship, user_ship_coords) == true
+  #         @board.place(ship, user_ship_coords)
+  #       elsif @board.valid_placement?(ship, user_ship_coords) == false
+  #         loop do
+  #           puts "Those are invalid coordinates. Please try again:"
+  #           puts "> "
+  #           user_ship_coords = gets.chomp.upcase.split(/ /)
+  #
+  #           if @board.valid_placement?(ship, user_ship_coords) == true
+  #             @board.place(ship, user_ship_coords)
+  #             # require "pry"; binding.pry
+  #             exit # Could be a helper-method
+  #           end
+  #         end
+  #       end
+  #     end
+  #   end
+  # end
 
   def all_ships_placed?
     ships_count = @ships.sum do |ship|

--- a/lib/player.rb
+++ b/lib/player.rb
@@ -15,7 +15,20 @@ class Player
 
   def ship_setup
     if @type == :auto
-      #auto generate coordinates
+      until all_ships_placed?
+        @ships.each do |ship|
+          until this_ship_placed?(ship)
+            auto_coords = []
+            possible = @board.cells.keys.shuffle
+            ship.length.times do
+              auto_coords << possible[0]
+              possible.rotate!
+            end
+            @board.valid_placement?(ship, auto_coords)
+            @board.validated_placement
+          end
+        end
+      end
     else
       until all_ships_placed?
         @ships.each do |ship|

--- a/lib/player.rb
+++ b/lib/player.rb
@@ -13,21 +13,11 @@ class Player
   end
 
 
+
   def ship_setup
     if @type == :auto
       until all_ships_placed?
-        @ships.each do |ship|
-          until this_ship_placed?(ship)
-            auto_coords = []
-            possible = @board.cells.keys.shuffle
-            ship.length.times do
-              auto_coords << possible[0]
-              possible.rotate!
-            end
-            @board.valid_placement?(ship, auto_coords)
-            @board.validated_placement
-          end
-        end
+        auto_generate_coordinates
       end
     else
       until all_ships_placed?
@@ -51,6 +41,22 @@ class Player
     end
   end
 
+  def auto_generate_coordinates
+    @ships.each do |ship|
+      until this_ship_placed?(ship)
+        auto_coords = []
+        possible = @board.cells.keys.shuffle
+        ship.length.times do
+          auto_coords << possible[0]
+          possible.rotate!
+        end
+        @board.valid_placement?(ship, auto_coords)
+        @board.validated_placement
+      end
+    end
+  end
+
+  
   def this_ship_placed?(ship)
     @board.cells.values.any? do |cell|
       cell.ship == ship

--- a/lib/player.rb
+++ b/lib/player.rb
@@ -24,16 +24,12 @@ class Player
           user_ship_coords = gets.chomp.upcase.split(/ /)
           result = @board.valid_placement?(ship, user_ship_coords)
           if result == false
-            "Develop helper method that tests if this singular ship was placed."
-            # @result2 = false
-            # until @result2 != false
-            #   require "pry"; binding.pry
-            #   puts "Those are invalid coordinates. Please try again: "
-            #   user_ship_coords2 = gets.chomp.upcase.split(/ /)
-            # @result2 != @board.valid_placement?(ship, user_ship_coords2)
-            #make loop for validated_placement
-            # end
+            until this_ship_placed?(ship)
+              puts "Those are invalid coordinates. Please try again: "
+              user_ship_coords2 = gets.chomp.upcase.split(/ /)
+            @board.valid_placement?(ship, user_ship_coords2)
             @board.validated_placement
+            end
           else
             @board.validated_placement
           end

--- a/lib/player.rb
+++ b/lib/player.rb
@@ -43,13 +43,27 @@ class Player
 
             if @board.valid_placement?(ship, user_ship_coords) == true
               @board.place(ship, user_ship_coords)
-              require "pry"; binding.pry
+              # require "pry"; binding.pry
               exit # Could be a helper-method
             end
           end
         end
       end
     end
+  end
+
+  def all_ships_placed?
+    ships_count = @ships.sum do |ship|
+      ship.length
+    end
+    ships_on_board = @board.cells.reduce(0) do |ships_placed_count, cell|
+      if cell[1].ship != nil
+        ships_placed_count += 1
+      end
+      ships_placed_count
+    end
+    ships_count == ships_on_board
+    # require "pry"; binding.pry
   end
 
 end

--- a/lib/player.rb
+++ b/lib/player.rb
@@ -57,6 +57,26 @@ class Player
     end
   end
 
+  def ship_count
+    @ships.sum do |ship|
+      ship.length
+    end
+  end
+
+  def ships_on_board
+    ships_on_board = @board.cells.reduce(0) do |ships_placed_count, cell|
+      if cell[1].ship != nil
+        ships_placed_count += 1
+      end
+      ships_placed_count
+    end
+  end
+
+  def all_ships_placed?
+    ship_count == ships_on_board
+  end
+
+
   # def ship_setup
   #   if @type == :auto
   #     # helper-method: auto_generation CALLS
@@ -97,17 +117,5 @@ class Player
   #   end
   # end
 
-  def all_ships_placed?
-    ships_count = @ships.sum do |ship|
-      ship.length
-    end
-    ships_on_board = @board.cells.reduce(0) do |ships_placed_count, cell|
-      if cell[1].ship != nil
-        ships_placed_count += 1
-      end
-      ships_placed_count
-    end
-    ships_count == ships_on_board
-  end
 
 end

--- a/test/board_test.rb
+++ b/test/board_test.rb
@@ -153,4 +153,26 @@ class BoardTest < Minitest::Test
     assert_equal expected2, @board.render(true)
   end
 
+  def test_validated_placement
+    board = Board.new
+    board.generate_cells
+    cruiser = Ship.new("Cruiser", 3)
+    submarine = Ship.new("Submarine", 2)
+
+    assert_equal true, board.valid_placement?(cruiser, ["A1", "A2", "A3"])
+    board.validated_placement
+    assert_equal cruiser, board.cells["A1"].ship
+    assert_equal cruiser, board.cells["A2"].ship
+    assert_equal cruiser, board.cells["A3"].ship
+
+
+    assert_equal true, board.valid_placement?(submarine, ["B1", "B2"])
+    board.validated_placement
+    assert_equal submarine, board.cells["B1"].ship
+    assert_equal submarine, board.cells["B2"].ship
+
+    #a helper method that tests to see if a valid_placement is true and then proceeds to automatically place the ship in question.
+
+  end
+
 end

--- a/test/player_test.rb
+++ b/test/player_test.rb
@@ -47,7 +47,7 @@ class PlayerTest < Minitest::Test
     @player1.add_ship(@submarine1)
     @player2.add_ship(@cruiser2)
     @player2.add_ship(@submarine2)
-
+    assert_equal [@cruiser2, @submarine2], @player2.ship_setup
     # Tested in pry. Is working currently before auto generation and user error.
   end
 

--- a/test/player_test.rb
+++ b/test/player_test.rb
@@ -57,7 +57,13 @@ class PlayerTest < Minitest::Test
     @player2.add_ship(@cruiser2)
     @player2.add_ship(@submarine2)
 
+    @player2.board.place(@cruiser2, ["A1","A2","A3"])
+    @player2.board.place(@submarine2, ["B1","B2"])
+
+
     assert_equal true, @player2.all_ships_placed?
+
+    assert_equal false, @player1.all_ships_placed?
 
   end
 

--- a/test/player_test.rb
+++ b/test/player_test.rb
@@ -51,4 +51,14 @@ class PlayerTest < Minitest::Test
     # Tested in pry. Is working currently before auto generation and user error.
   end
 
+  def test_it_can_tell_all_ships_are_placed
+    @player1.add_ship(@cruiser1)
+    @player1.add_ship(@submarine1)
+    @player2.add_ship(@cruiser2)
+    @player2.add_ship(@submarine2)
+
+    assert_equal true, @player2.all_ships_placed?
+
+  end
+
 end

--- a/test/player_test.rb
+++ b/test/player_test.rb
@@ -88,6 +88,7 @@ class PlayerTest < Minitest::Test
 
     @player1.ship_setup
     assert_equal true, @player1.all_ships_placed?
+    assert_equal false, @player2.all_ships_placed?
 
   end
 

--- a/test/player_test.rb
+++ b/test/player_test.rb
@@ -43,6 +43,7 @@ class PlayerTest < Minitest::Test
   end
 
   def test_player_can_place_ship
+    skip
     @player1.add_ship(@cruiser1)
     @player1.add_ship(@submarine1)
     @player2.add_ship(@cruiser2)
@@ -64,6 +65,20 @@ class PlayerTest < Minitest::Test
     assert_equal true, @player2.all_ships_placed?
 
     assert_equal false, @player1.all_ships_placed?
+
+  end
+
+  def test_it_can_determine_if_one_ship_is_placed
+    @player1.add_ship(@cruiser1)
+    @player1.add_ship(@submarine1)
+    @player2.add_ship(@cruiser2)
+    @player2.add_ship(@submarine2)
+
+    @player2.board.place(@cruiser2, ["A1","A2","A3"])
+    @player2.board.place(@submarine2, ["B1","B2"])
+
+    assert_equal false, @player1.this_ship_placed?(@cruiser1)
+    assert_equal true, @player2.this_ship_placed?(@cruiser2)
 
   end
 

--- a/test/player_test.rb
+++ b/test/player_test.rb
@@ -43,12 +43,10 @@ class PlayerTest < Minitest::Test
   end
 
   def test_player_can_place_ship
-    skip
     @player1.add_ship(@cruiser1)
     @player1.add_ship(@submarine1)
     @player2.add_ship(@cruiser2)
     @player2.add_ship(@submarine2)
-    assert_equal [@cruiser2, @submarine2], @player2.ship_setup
     # Tested in pry. Is working currently before auto generation and user error.
   end
 

--- a/test/player_test.rb
+++ b/test/player_test.rb
@@ -80,4 +80,15 @@ class PlayerTest < Minitest::Test
 
   end
 
+  def test_it_can_auto_generate_coordinates
+    @player1.add_ship(@cruiser1)
+    @player1.add_ship(@submarine1)
+    @player2.add_ship(@cruiser2)
+    @player2.add_ship(@submarine2)
+
+    @player1.ship_setup
+    assert_equal true, @player1.all_ships_placed?
+
+  end
+
 end


### PR DESCRIPTION
New Helper Methods!!!!!!!

-  `auto_generate_coordinates`: takes the keys from our `@board.cells` hash, shuffles them, inputs them into an array by the `length of the ship`, and if `valid_placement?` == true, `validated_placement` places the ship.

- `this_ship_placed?(ship)`: evaluates to true or false by checking if any of the cells contain this ship.  Fully relies of strong `valid_placement?` methods.

- `ships_on_board`: counts how many cells on the board contain a ship

- `ship_count`: takes the total sum of the lengths of each ship

- `all_ships_placed?`: evaluates to true if ships_on_board == ship_count


These boolean helper methods allowed me to write more until <condition> loops that automatically placed a ship without relying on us having to remember to call that method.  I also utilized these boolean helper methods to refactor our `:user` ship setup method.  But I am having trouble seeing how we can refactor pieces of the `:user` section.  Could you take a look and see if you notice anything that can be "moved" into a helper method? 

I am also wondering if we have our @type in player class parameter default to `:user` so that when we initiate our two players it'll look like this:

```ruby
computer = Player.new(:auto, @board)
player = Player.new(@board)
```

So the top of the class will look like this:

```ruby
class Player
  def initialize(type=:user, board)
       @type = type
       @board = board
  end
  our_methods
end
```

This way, we can account for the Player automatically being a user until we mark it.
Also, we don't HAVE to do that.  All tests pass as it is right now.